### PR TITLE
Add support for multiple certificates in ocsp response, add ecdsa-sha256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.4"
 tracing = "0.1"
 tracing-futures = "0.2"
 chrono = "0.4"
+yasna = "0.5.2"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.2", features = [

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -161,11 +161,21 @@ pub const ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT: &str = "1.2.840.113549.1.1.11";
 pub const ALGO_SHA256_WITH_RSA_ENCRYPTION_NAME: &str =
     "{iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-1(1) sha256-with-rsa-signature(11)}";
 
+pub(crate) const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_ID: usize = 13;
+/// bytes in DER
+pub const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX: [u8; 8] =
+    [0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02];
+///dot notation
+pub const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_DOT: &str = "1.2.840.10045.4.3.2";
+///asn1 notation
+pub const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME: &str =
+    "{iso(1) member-body(2) us(840) ansi-x962(10045) signatures(4) ecdsa-with-SHA2(3) ecdsa-with-SHA256(2)}";
+
 /// NOT the number of OID, highest num in OID_MAX  
 /// eg.  
 /// oid_map contains 4 algos [0..3]  
 /// OID_MAX_ID = 3
-pub(crate) const OID_MAX_ID: usize = 12;
+pub(crate) const OID_MAX_ID: usize = 13;
 
 lazy_static! {
     /// search oid index by oid binary
@@ -183,12 +193,13 @@ lazy_static! {
         (ALGO_SHA1_WITH_RSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA1_WITH_RSA_ENCRYPTION_ID),
         (OCSP_RESPONSE_BASIC_HEX.to_vec(), OCSP_RESPONSE_BASIC_ID),
         (ALGO_SHA256_WITH_RSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA256_WITH_RSA_ENCRYPTION_ID),
+        (ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA256_WITH_ECDSA_ENCRYPTION_ID),
     ]
     .into_iter()
     .collect();
 
     /// list of ocsp extension oid names
-    pub static ref OCSP_OID_NAME_LIST: [&'static str; 13] = [
+    pub static ref OCSP_OID_NAME_LIST: [&'static str; 14] = [
         OCSP_EXT_NONCE_NAME,
         OCSP_EXT_CRLREF_NAME,
         OCSP_EXT_RESP_TYPE_NAME,
@@ -202,10 +213,11 @@ lazy_static! {
         ALGO_SHA1_WITH_RSA_ENCRYPTION_NAME,
         OCSP_RESPONSE_BASIC_NAME,
         ALGO_SHA256_WITH_RSA_ENCRYPTION_NAME,
+        ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME,
     ];
 
     /// list of ocsp extension oid in num dot format
-    pub static ref OCSP_OID_DOT_LIST: [&'static str; 13] = [
+    pub static ref OCSP_OID_DOT_LIST: [&'static str; 14] = [
         OCSP_EXT_NONCE_DOT,
         OCSP_EXT_CRLREF_DOT,
         OCSP_EXT_RESP_TYPE_DOT,
@@ -219,10 +231,11 @@ lazy_static! {
         ALGO_SHA1_WITH_RSA_ENCRYPTION_DOT,
         OCSP_RESPONSE_BASIC_DOT,
         ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT,
+        ALGO_SHA256_WITH_ECDSA_ENCRYPTION_DOT,
     ];
 
     /// list of ocsp extension oid in bytes
-    pub static ref OCSP_OID_HEX_LIST: [Bytes; 13] = [
+    pub static ref OCSP_OID_HEX_LIST: [Bytes; 14] = [
         OCSP_EXT_NONCE_HEX.to_vec(),
         OCSP_EXT_CRLREF_HEX.to_vec(),
         OCSP_EXT_RESP_TYPE_HEX.to_vec(),
@@ -236,6 +249,7 @@ lazy_static! {
         ALGO_SHA1_WITH_RSA_ENCRYPTION_HEX.to_vec(),
         OCSP_RESPONSE_BASIC_HEX.to_vec(),
         ALGO_SHA256_WITH_RSA_ENCRYPTION_HEX.to_vec(),
+        ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX.to_vec(),
     ];
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -380,9 +380,14 @@ impl BasicResponse {
         let mut pad = vec![0x00u8];
         pad.extend(&self.signature);
         v.extend(asn1_encode_bit_string(&pad)?);
-        // FIXME:
-        if let Some(_c) = &self.certs {
-            unimplemented!()
+        if let Some(c) = &self.certs {
+            let d =
+                yasna::construct_der_seq(|w| w.next().write_sequence_of(|w| w.next().write_der(c)));
+            let tag = yasna::Tag::context(0);
+            let pc = yasna::PCBit::Constructed;
+            let tv = yasna::models::TaggedDerValue::from_tag_pc_and_bytes(tag, pc, d);
+            let der = yasna::construct_der(|w| w.write_tagged_der(&tv));
+            v.extend(der);
         }
 
         let len = asn1_encode_length(v.len())?;

--- a/src/response.rs
+++ b/src/response.rs
@@ -355,17 +355,17 @@ pub struct BasicResponse {
     /// the certs field of BasicOCSPResponse that help the OCSP client verify  
     /// the responder's signature.  
     /// If no certificates are included, then certs SHOULD be absent
-    pub certs: Option<Bytes>,
+    pub certs: Option<Vec<Bytes>>,
 }
 
 impl BasicResponse {
     /// return new response data
-    pub fn new(data: ResponseData, algo: Oid, sign: Bytes, cert: Option<Bytes>) -> Self {
+    pub fn new(data: ResponseData, algo: Oid, sign: Bytes, certs: Option<Vec<Bytes>>) -> Self {
         BasicResponse {
             tbs_resp_data: data,
             signature_algo: algo,
             signature: sign,
-            certs: cert,
+            certs,
         }
     }
 
@@ -380,9 +380,14 @@ impl BasicResponse {
         let mut pad = vec![0x00u8];
         pad.extend(&self.signature);
         v.extend(asn1_encode_bit_string(&pad)?);
-        if let Some(c) = &self.certs {
+        if let Some(certs) = &self.certs {
             let d =
-                yasna::construct_der_seq(|w| w.next().write_sequence_of(|w| w.next().write_der(c)));
+                yasna::construct_der_seq(|w| {
+                    w.next().write_sequence_of(|w| 
+                        for c in certs {
+                            w.next().write_der(c)
+                        })
+                    });
             let tag = yasna::Tag::context(0);
             let pc = yasna::PCBit::Constructed;
             let tv = yasna::models::TaggedDerValue::from_tag_pc_and_bytes(tag, pc, d);


### PR DESCRIPTION
This pull request uses the yasna crate to add support for certs in a basicresponse.
It adds support for ECDSA SHA256 signatures.
It also adds support for multiple certificates in a basicresponse.